### PR TITLE
Manage scoped models for tabs toggling

### DIFF
--- a/app/views/rails_admin/main/_form_globalize_tabs.html.haml
+++ b/app/views/rails_admin/main/_form_globalize_tabs.html.haml
@@ -1,5 +1,5 @@
 - field.translations(true) # fetch translations and memoize them
-- key = field.abstract_model.model_name.parameterize
+- key = field.abstract_model.model_name.parameterize.gsub("::", "_")
 
 .controls
   .globalize-errors


### PR DESCRIPTION
Javascript error on tabs toggling because of the data-target when model is scoped. Altered the key and escaped the "::" with an underscore so it's longer a problem.
